### PR TITLE
Cartography → web-map pin sync + Turtleheim frontend + CI

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -41,21 +41,19 @@ jobs:
 
       - name: Download Valheim dedicated server (app 896660, anonymous, with retry)
         if: steps.cache-valheim.outputs.cache-hit != 'true'
+        shell: bash
         run: |
-          set -uo pipefail
-          # steamcmd self-bootstrap (first invocation often updates itself)
-          steamcmd +quit || true
+          set +e   # do NOT abort on a single steamcmd failure; we retry below
+          DLL="$VALHEIM_DIR/valheim_server_Data/Managed/assembly_valheim.dll"
+          steamcmd +quit   # self-bootstrap (first run updates itself)
           for attempt in 1 2 3 4; do
             echo "::group::steamcmd attempt $attempt"
             steamcmd +force_install_dir "$VALHEIM_DIR" +login anonymous +app_update 896660 validate +quit
-            code=$?
             echo "::endgroup::"
-            if [ -f "$VALHEIM_DIR/valheim_server_Data/Managed/assembly_valheim.dll" ]; then
-              echo "Valheim assemblies present."; break
-            fi
-            echo "attempt $attempt failed (exit $code); retrying in 15s..."; sleep 15
+            if [ -f "$DLL" ]; then echo "Valheim assemblies present."; break; fi
+            echo "attempt $attempt failed; retrying in 15s..."; sleep 15
           done
-          test -f "$VALHEIM_DIR/valheim_server_Data/Managed/assembly_valheim.dll"
+          if [ ! -f "$DLL" ]; then echo "ERROR: Valheim assemblies never downloaded"; exit 1; fi
 
       - name: Assemble libs/
         working-directory: mods/WebMapCartographySync

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,76 @@
+name: Build WebMapCartographySync
+
+# Compiles the server-side cartography→WebMap pin plugin entirely in CI.
+# Reference assemblies are fetched here (steamcmd for Valheim, Thunderstore for BepInEx,
+# GitHub for WebMap) so no copyrighted DLLs live in the repo. Artifact: WebMapCartographySync.dll
+
+on:
+  push:
+    paths:
+      - "mods/WebMapCartographySync/**"
+      - ".github/workflows/build-plugin.yml"
+  pull_request:
+    paths:
+      - "mods/WebMapCartographySync/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mods/WebMapCartographySync
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Cache Valheim dedicated server (Managed assemblies)
+        id: cache-valheim
+        uses: actions/cache@v4
+        with:
+          path: ~/valheim-server/valheim_server_Data/Managed
+          key: valheim-managed-896660-v1
+
+      - name: Setup steamcmd
+        if: steps.cache-valheim.outputs.cache-hit != 'true'
+        uses: CyberAndrii/setup-steamcmd@v1
+
+      - name: Download Valheim dedicated server (app 896660, anonymous)
+        if: steps.cache-valheim.outputs.cache-hit != 'true'
+        run: steamcmd +force_install_dir "$HOME/valheim-server" +login anonymous +app_update 896660 validate +quit
+
+      - name: Assemble libs/
+        run: |
+          set -euo pipefail
+          mkdir -p libs
+          M="$HOME/valheim-server/valheim_server_Data/Managed"
+          cp "$M/assembly_valheim.dll" "$M/assembly_utils.dll" \
+             "$M/UnityEngine.dll" "$M/UnityEngine.CoreModule.dll" libs/
+
+          # BepInEx core (latest BepInExPack_Valheim from Thunderstore)
+          BEP_URL=$(curl -sSL https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/ | jq -r '.latest.download_url')
+          curl -sSL "$BEP_URL" -o bep.zip
+          unzip -o -q bep.zip -d bep
+          cp bep/BepInExPack_Valheim/BepInEx/core/BepInEx.dll \
+             bep/BepInExPack_Valheim/BepInEx/core/0Harmony.dll libs/
+
+          # WebMap (matches the version deployed on the server)
+          curl -sSL https://github.com/h0tw1r3/valheim-webmap/releases/download/v2.7.1/WebMap-v2.7.1.zip -o webmap.zip
+          unzip -o -q webmap.zip -d webmap
+          cp webmap/WebMap-v2.7.1/WebMap.dll libs/
+
+          echo "libs/ contents:"; ls -la libs
+
+      - name: Build (Release)
+        run: dotnet build WebMapCartographySync.csproj -c Release -p:LibsDir="$PWD/libs"
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebMapCartographySync
+          path: mods/WebMapCartographySync/bin/Release/WebMapCartographySync.dll
+          if-no-files-found: error

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -14,12 +14,12 @@ on:
       - "mods/WebMapCartographySync/**"
   workflow_dispatch:
 
+env:
+  VALHEIM_DIR: ${{ github.workspace }}/.valheim-server
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: mods/WebMapCartographySync
     steps:
       - uses: actions/checkout@v4
 
@@ -32,22 +32,37 @@ jobs:
         id: cache-valheim
         uses: actions/cache@v4
         with:
-          path: ~/valheim-server/valheim_server_Data/Managed
-          key: valheim-managed-896660-v1
+          path: ${{ env.VALHEIM_DIR }}/valheim_server_Data/Managed
+          key: valheim-managed-896660-v2
 
       - name: Setup steamcmd
         if: steps.cache-valheim.outputs.cache-hit != 'true'
         uses: CyberAndrii/setup-steamcmd@v1
 
-      - name: Download Valheim dedicated server (app 896660, anonymous)
+      - name: Download Valheim dedicated server (app 896660, anonymous, with retry)
         if: steps.cache-valheim.outputs.cache-hit != 'true'
-        run: steamcmd +force_install_dir "$HOME/valheim-server" +login anonymous +app_update 896660 validate +quit
+        run: |
+          set -uo pipefail
+          # steamcmd self-bootstrap (first invocation often updates itself)
+          steamcmd +quit || true
+          for attempt in 1 2 3 4; do
+            echo "::group::steamcmd attempt $attempt"
+            steamcmd +force_install_dir "$VALHEIM_DIR" +login anonymous +app_update 896660 validate +quit
+            code=$?
+            echo "::endgroup::"
+            if [ -f "$VALHEIM_DIR/valheim_server_Data/Managed/assembly_valheim.dll" ]; then
+              echo "Valheim assemblies present."; break
+            fi
+            echo "attempt $attempt failed (exit $code); retrying in 15s..."; sleep 15
+          done
+          test -f "$VALHEIM_DIR/valheim_server_Data/Managed/assembly_valheim.dll"
 
       - name: Assemble libs/
+        working-directory: mods/WebMapCartographySync
         run: |
           set -euo pipefail
           mkdir -p libs
-          M="$HOME/valheim-server/valheim_server_Data/Managed"
+          M="$VALHEIM_DIR/valheim_server_Data/Managed"
           cp "$M/assembly_valheim.dll" "$M/assembly_utils.dll" \
              "$M/UnityEngine.dll" "$M/UnityEngine.CoreModule.dll" libs/
 
@@ -66,6 +81,7 @@ jobs:
           echo "libs/ contents:"; ls -la libs
 
       - name: Build (Release)
+        working-directory: mods/WebMapCartographySync
         run: dotnet build WebMapCartographySync.csproj -c Release -p:LibsDir="$PWD/libs"
 
       - name: Upload plugin artifact

--- a/docs/cartography-pin-deletion.md
+++ b/docs/cartography-pin-deletion.md
@@ -1,0 +1,82 @@
+# Investigation: Deleting pins from the web map
+
+**Question:** I want to delete pins from the HTML map. If I delete a pin from my local in-game
+map and then click "record discoveries" at a cartography table, will it remove the older entry
+from the web map?
+
+**Short answer: No — not today, and deletion is fundamentally harder than addition.** The current
+plugin is **additive-only**: it accumulates the union of every pin it ever sees and never removes
+anything. So deleting locally + recording leaves the pin on the web map.
+
+---
+
+## What actually happens when you delete locally + record
+
+Verified from `Minimap.GetSharedMapData` (the function the cartography "write" calls): it writes
+the writer's **current** `m_pins` (all saved, non-Death pins). So:
+
+1. You delete a pin in-game → it's gone from your `m_pins`.
+2. You "record discoveries" → the table ZDO is overwritten with your *remaining* pins (the deleted
+   one is absent). ✅ the table no longer has it.
+3. **But our plugin never removes** — it already mirrored that pin to WebMap and keeps it. ❌ the
+   web map still shows it.
+
+So the table *does* reflect your deletion; the plugin just doesn't act on absences.
+
+## Why deletion is hard (the core constraint)
+
+The cartography table stores **only the last writer's pins** (it replaces, doesn't merge —
+verified). That's exactly why the plugin accumulates the union. The consequence: **"a pin is
+missing from the table" is ambiguous** —
+
+- did its owner delete it, **or**
+- did a *different* player just overwrite the table with their own pins?
+
+You can't tell from the table alone. A naive "mirror the table exactly" would make each writer
+wipe everyone else's pins. So deletion needs to be smarter than addition.
+
+## Options
+
+### 1. Per-owner reconciliation — RECOMMENDED
+Every pin carries an `ownerID`. Treat each write as the authoritative current set **for the
+owners present in that write**:
+
+- For each `ownerID` in the write: `removed = previouslyMirrored[ownerID] − currentWrite[ownerID]`
+  → remove those from WebMap.
+- Pins owned by players **not** in this write are left alone (preserves the union across
+  multi-writer overwrites).
+
+Handles the real use case (each player curates their own pins). Multi-writer safe: if player Y
+downloaded X's pins and re-writes, Y's write contains both owners, so each is reconciled correctly.
+
+**Known limitation:** if a player deletes **all** their pins and records, their `ownerID` won't
+appear in the write at all, so we can't tell their pins should be cleared. Escape hatch: WebMap's
+built-in `!undoPin` / `!deletePin <text>` chat commands, or a manual web-side delete.
+
+### 2. Explicit delete command / web action
+Lean on WebMap's existing removal: `MapDataServer.RemovePin(idx)` (broadcasts `rmpin`), and the
+in-game `!undoPin` / `!deletePin <text>` commands. Lowest effort; manual, not automatic from the
+map screen.
+
+### 3. Full per-table reconciliation — NOT recommended
+Mirror the table's current set exactly (add missing, remove extras). Simple, but the last writer
+wipes everyone else's pins. Only safe on a single-writer server.
+
+## Recommendation
+
+Add **opt-in per-owner reconciliation** (#1), gated behind a config flag (default off) so the
+additive behavior stays the safe default. Document the "delete-all-then-record" edge case and
+point at `!deletePin` as the manual fallback.
+
+## Implementation sketch (for a v0.2)
+
+- Track mirrored pins as `ownerID → set<pinId>` (extend the existing dedupe state).
+- Add `WebMapBridge.RemovePin(pinId)`: find the index in `MapDataServer.pins` whose CSV column 1
+  (`pinId`) matches, call `RemovePin(idx)`, then `SavePins()`. (`RemovePin(int)` is confirmed
+  present in WebMap and already broadcasts `rmpin`.)
+- In `ScanOnce`, after collecting this scan's pins grouped by `ownerID`: for each owner present,
+  diff against previously-mirrored and `RemovePin` the difference.
+- New config: `[Deletion] enable_owner_reconciliation = false`.
+
+Effort: moderate, additive to the existing scanner — same build/deploy loop as v0.1
+(see [cartography-pin-sync-spec.md](./cartography-pin-sync-spec.md)).

--- a/docs/cartography-pin-sync-spec.md
+++ b/docs/cartography-pin-sync-spec.md
@@ -91,7 +91,7 @@ The decompressed payload is a `ZPackage` with this **exact** layout (verified ag
 `Minimap.GetSharedMapData` + `ReadExploredArray`, current map-data **version `2`**):
 
 ```
-int    version              // currently 2
+int    version              // live game = 3 (was 2; v3 added per-pin author)
 int    exploredLength        // == textureSize * textureSize
 bool[] explored              // `exploredLength` bools, 1 byte each  (we skip these)
 int    numPins               // only pins with m_save==true AND type != Death are written
@@ -101,7 +101,10 @@ repeat numPins:
     Vector3 pos              // 3 floats x,y,z  (use x,z; y is unused on the web map)
     int     type             // Minimap.PinType
     bool    checked
+    string  author           // v3 ONLY: PlatformUserID.ToString() (e.g. "Steam_7656...") — read & discard
 ```
+> Confirmed against live server data: `version=3`, `exploredLength=4194304` (2048²). v2 had no
+> author field; reading it only when `version >= 3` keeps both formats working.
 
 Reference parser (no `Minimap` needed — pure ZPackage + the `Minimap.PinType` enum, all
 available on a dedicated server):

--- a/docs/cartography-pin-sync-spec.md
+++ b/docs/cartography-pin-sync-spec.md
@@ -1,0 +1,348 @@
+# Spec: Server-Side Cartography → WebMap Pin Sync
+
+**Goal:** When players upload their map markers to a **cartography table** in-game, mirror
+those pins onto the WebMap web map — **server-side only, no client mods**, and **without
+double-posting** pins that already exist.
+
+This is a new BepInEx **server plugin** (working name: `WebMapCartographySync`) that lives
+beside WebMap in `BepInEx/plugins/`. Clients stay 100% vanilla.
+
+---
+
+## 1. Why this is the right approach
+
+| In-game action | Crosses the network? | Server can observe it? |
+|---|---|---|
+| Personal map pin (open map, click) | No — local `Minimap.AddPin`, saved to the player's own character file | **No** |
+| Ping (middle-click map) | Yes — `ChatMessage` RPC, type `Ping` | Yes (transient only) |
+| `!pin` chat command | Yes — `ChatMessage` RPC | Yes (WebMap already handles) |
+| **Write to cartography table** | **Yes — data is stored in the table's networked ZDO, persisted in the world save** | **Yes ← this spec** |
+
+A cartography table is a placed piece backed by a **ZDO** (networked, server-persisted
+object). When a player interacts with the *writing* side, the game serializes their
+explored map **and their map pins** into that ZDO. The server holds every ZDO, so the pin
+data is readable server-side with no client involvement. This is the only passive,
+no-client-mod path that yields **persistent** pins (pings are transient; `!pin` requires
+players to type commands).
+
+**Trade-off to accept:** it's not automatic — a player must walk to a cartography table and
+click "write" to share. That's a deliberate, normal in-game gesture.
+
+---
+
+## 2. Architecture
+
+```
+Player writes map+pins to cartography table (vanilla client)
+        │  (data serialized into the table's ZDO, synced to server)
+        ▼
+Dedicated server's ZDOMan  ── holds the table ZDO + its byte[] map-data field
+        │
+        ▼
+WebMapCartographySync plugin (this spec)
+   1. Poll every cartography-table ZDO on an interval
+   2. Read + decompress the map-data byte[]
+   3. Hand-parse the pin list out of it (no Minimap on server)
+   4. Dedupe against pins already in WebMap
+   5. For each NEW pin → call WebMap's MapDataServer.AddPin(...) + SavePins()
+        │
+        ▼
+WebMap broadcasts the pin over WebSocket + persists it to pins.csv → appears on the web map
+```
+
+No Harmony patches are strictly required for v1 — polling `ZDOMan` is simpler and more
+robust on a headless server than trying to hook a client-side write path. (A patch-based
+trigger is listed as a future optimization in §9.)
+
+---
+
+## 3. The hard part: reading the table's pin data server-side
+
+### 3.1 Find the cartography-table ZDOs
+
+```csharp
+// Prefab name to VERIFY in your game version (ZNetScene prefab list):
+const string CartographyPrefab = "piece_cartographytable";
+int prefabHash = CartographyPrefab.GetStableHashCode();
+
+var zdos = new List<ZDO>();
+// Signature varies by Valheim version — verify in assembly_valheim:
+//   ZDOMan.instance.GetAllZDOsWithPrefab(string prefab, List<ZDO> zdos)  // returns bool
+ZDOMan.instance.GetAllZDOsWithPrefab(CartographyPrefab, zdos);
+```
+
+If `GetAllZDOsWithPrefab` isn't available/stable in the target version, fall back to
+iterating `ZDOMan`'s object index and filtering by `zdo.GetPrefab() == prefabHash`.
+
+### 3.2 Read the map-data byte array from the ZDO — ✅ CONFIRMED
+
+Confirmed from decompiled `MapTable.OnWrite`/`OnRead`: the cartography table stores its data
+in the ZDO under **`ZDOVars.s_data`**, **`Utils.Compress`'d**, and the payload is exactly the
+output of `Minimap.GetSharedMapData()`.
+
+```csharp
+byte[] raw = zdo.GetByteArray(ZDOVars.s_data);   // null if the table was never written to
+if (raw == null || raw.Length == 0) continue;
+byte[] data = Utils.Decompress(raw);
+```
+
+### 3.3 Decompress + parse the pins (no Minimap) — ✅ CONFIRMED FORMAT
+
+The decompressed payload is a `ZPackage` with this **exact** layout (verified against decompiled
+`Minimap.GetSharedMapData` + `ReadExploredArray`, current map-data **version `2`**):
+
+```
+int    version              // currently 2
+int    exploredLength        // == textureSize * textureSize
+bool[] explored              // `exploredLength` bools, 1 byte each  (we skip these)
+int    numPins               // only pins with m_save==true AND type != Death are written
+repeat numPins:
+    long    ownerID          // pin owner's playerID (0 written as the writer's id)
+    string  name             // the pin's LABEL text (not a player name)
+    Vector3 pos              // 3 floats x,y,z  (use x,z; y is unused on the web map)
+    int     type             // Minimap.PinType
+    bool    checked
+```
+
+Reference parser (no `Minimap` needed — pure ZPackage + the `Minimap.PinType` enum, all
+available on a dedicated server):
+
+```csharp
+ZPackage pkg = new ZPackage(data);
+int version       = pkg.ReadInt();      // expect 2
+int exploredLength = pkg.ReadInt();     // == textureSize²; comes from the stream, no need to assume size
+SkipBytes(pkg, exploredLength);         // each bool == 1 byte in ZPackage
+
+var pins = new List<ParsedPin>();
+if (version >= 2)
+{
+    int numPins = pkg.ReadInt();
+    for (int i = 0; i < numPins; i++)
+    {
+        long ownerID  = pkg.ReadLong();
+        string label  = pkg.ReadString();
+        Vector3 pos   = pkg.ReadVector3();
+        var type      = (Minimap.PinType)pkg.ReadInt();
+        bool isChecked = pkg.ReadBool();
+        pins.Add(new ParsedPin(ownerID, label, pos, type, isChecked));
+    }
+}
+```
+
+`SkipBytes` advances the reader without allocating — set the underlying
+`BinaryReader.BaseStream.Position` via reflection, else loop `pkg.ReadByte()`. There is
+**one** exploration mask (not two): `GetSharedMapData` ORs `m_explored | m_exploredOthers`
+into a single array before writing. `ReadExploredArray` returns null on a size mismatch, so
+guard for a short/garbled package.
+
+> Only the leading `version` int could change in a future Valheim update. If `version != 2`,
+> log and re-confirm `GetSharedMapData` — everything else keys off the in-stream
+> `exploredLength`, so it's robust to texture-size changes.
+
+### 3.4 Two findings that shape the design — ✅ CONFIRMED
+
+1. **Pins are REPLACED per write, exploration is MERGED.** `GetSharedMapData(oldMapData)`
+   merges the old *exploration* mask, but for **pins it writes only the writer's own
+   `m_pins`** — the previous writer's pins are NOT carried forward. So the table ZDO only ever
+   holds the **last writer's** pin set. → Our plugin **must accumulate the union itself**
+   across poll snapshots (§6). This confirms the wiki's "stores the last person's pins."
+2. **Vanilla already dedups by proximity.** `AddSharedMapData` only adds a shared pin if
+   `!HavePinInRange(pos, 1f)` — a **1-unit radius**. We mirror this for our own dedupe
+   (§6) so we match vanilla's notion of "same pin."
+
+---
+
+## 4. Mapping Valheim pin types → WebMap types
+
+WebMap pin types are: `dot`, `fire`, `mine`, `house`, `cave` (from its `!pin` command set
+and `mapIcons.png`). Valheim's placeable pins are `PinType.Icon0..Icon4` (+ `Boss`, etc.).
+Provide a config-driven mapping; sensible defaults (CONFIRM enum values per version):
+
+| Valheim `PinType` | WebMap type |
+|---|---|
+| `Icon0` | `dot` |
+| `Icon1` | `fire` |
+| `Icon2` | `mine` |
+| `Icon3` | `house` |
+| `Icon4` | `cave` |
+| `Boss` / others | `dot` (fallback) |
+
+Only mirror the **placeable** types players actually use (Icon0–4, maybe Boss). Skip
+`Death`, `Player`, `Shout`, `Bonfire`, `Ping`, etc.
+
+---
+
+## 5. WebMap integration (confirmed from WebMap v2.7.1 source)
+
+WebMap holds pins as a `List<string>` (`MapDataServer.pins`), one CSV line each:
+
+```
+{id},{pinId},{type},{name},{x},{z},{pinText}
+        id      = owner identifier (steamid in WebMap's own pins)
+        pinId   = unique pin id
+        type    = webmap type string (dot/fire/mine/house/cave)
+        name    = display/author name
+        x, z    = coords, formatted "F2" (invariant culture)
+        pinText = label
+```
+
+Relevant API:
+```csharp
+MapDataServer.AddPin(string id, string pinId, string type, string name,
+                     Vector3 position, string pinText)   // adds to list + WebSocket broadcast
+MapDataServer.SavePins()  // static — writes pins.csv (BepInEx/plugins/WebMap/map_data/<world>/pins.csv)
+```
+
+**Getting a reference to WebMap's `MapDataServer`:** both plugins run in the same process.
+Add a reference to `WebMap.dll` (publicized) and read its static `mapDataServer` field
+(`WebMap.WebMap.mapDataServer`), or reach it via reflection to avoid a hard build-time
+dependency. Then per new pin:
+
+```csharp
+mapDataServer.AddPin(ownerId, pinId, webmapType, authorName, pos, label);
+// after the batch:
+WebMap.WebMap.SavePins();   // persist once per poll cycle, only if something changed
+```
+
+> Do **not** just append to `pins.csv` directly — WebMap caches pins in memory and would
+> overwrite your lines on its next `SavePins()`, and direct writes don't broadcast live.
+> Always go through `AddPin` so the pin both broadcasts and is included in WebMap's own saves.
+
+---
+
+## 6. Dedupe (the "no double-post" requirement)
+
+Make each pin **deterministically identified** so re-reads are idempotent. Mirror vanilla's
+own notion of "same pin" — `HavePinInRange(pos, 1f)`, a 1-unit radius (§3.4).
+
+- **Dedupe key:** `"{ownerId}|{type}|{x:F0}|{z:F0}|{label}"` (round coords to ~1 unit to
+  match vanilla's 1f `HavePinInRange` and absorb float jitter). Optionally drop `ownerId` if
+  you want one pin per location regardless of who placed it. For stricter proximity dedupe,
+  keep a list of accepted `(type,pos)` and reject any new pin within 1f of an existing one.
+- **Deterministic `pinId`:** stable hash of the dedupe key (e.g. SHA1/`GetStableHashCode`
+  of the key string). Same pin → same `pinId` every time.
+- **On plugin startup:** build an in-memory `HashSet<string>` of seen keys by scanning the
+  existing `mapDataServer.pins` lines (parse out pinId / reconstruct keys). This survives
+  restarts because WebMap reloads `pins.csv`.
+- **Per poll:** for each parsed cartography pin, compute its key; if already in the set,
+  **skip**; otherwise `AddPin` and add the key to the set.
+
+This also neutralizes the cartography table's "only the last writer's pins are stored"
+behavior: we **accumulate the union** of every snapshot we ever see into WebMap, so a pin
+that scrolls out of the table later still stays on the web map.
+
+**v1 scope = additive only.** Pin *removal*/uncheck sync is out of scope (see §9).
+
+---
+
+## 7. Config (BepInEx `.cfg`)
+
+```
+[General]
+poll_interval_seconds = 30      # how often to scan cartography tables
+enabled               = true
+
+[Mapping]
+icon0 = dot
+icon1 = fire
+icon2 = mine
+icon3 = house
+icon4 = cave
+default = dot
+
+[Dedupe]
+include_owner_in_key  = true    # false = one pin per location regardless of author
+coord_rounding        = 1.0
+```
+
+---
+
+## 8. Project skeleton & build
+
+```
+WebMapCartographySync/
+├── WebMapCartographySync.csproj
+├── Plugin.cs                 # BepInEx entry; starts the poll coroutine on a hidden GameObject
+├── CartographyReader.cs      # find table ZDOs, decompress, parse pins (§3)
+├── PinFormat.cs              # ParsedPin, PinType→WebMap mapping (§4)
+├── WebMapBridge.cs           # reflection/refs into WebMap MapDataServer (§5)
+├── Dedup.cs                  # key building + seen-set (§6)
+└── PluginConfig.cs
+```
+
+- **Target:** .NET (match WebMap / your Valheim version — same TFM as WebMap's csproj).
+- **References:** `BepInEx`, `HarmonyX` (only if you add patches later), `assembly_valheim`,
+  `assembly_utils`, and `WebMap.dll`. Use **BepInEx.AssemblyPublicizer** for
+  `assembly_valheim` so internal/private members (ZDO keys, `mapDataServer`) are reachable —
+  this is the same approach BetterCartographyTable uses (`AssemblyPublicizerTool`).
+- **No Jötunn needed** — BCT requires it for client UI; we have no UI, so we skip it.
+- **Output:** a single `WebMapCartographySync.dll`.
+
+### Deploy
+Drop the DLL into `BepInEx/plugins/` (it can sit loose next to the other single-file mods,
+or in its own folder). **Stop the server before adding it** (config-write-on-shutdown rule).
+Restart; confirm load in `BepInEx/LogOutput.log`.
+
+---
+
+## 9. Open questions / future work
+
+The format risk is **resolved** (§3.2–3.4 confirmed against decompiled source). Remaining:
+
+1. **Map-data `version` watch** — currently `2`. If a Valheim update bumps it, re-confirm
+   `GetSharedMapData`. Everything else keys off the in-stream `exploredLength`, so it's robust.
+2. **`Minimap.PinType` enum values** (§4) — confirm Icon0–4 map to the icons you want; the
+   enum is stable but worth a glance after major updates.
+3. **Removal/uncheck sync** — v1 is additive. Supporting removals conflicts with the
+   "union accumulate" strategy (needed because the table only holds the last writer's pins,
+   §3.4); design a separate reconciliation mode if wanted.
+4. **Patch-based trigger (optimization)** — instead of polling, Postfix-patch the server-side
+   ZDO write for cartography prefabs to react immediately. Lower latency, more version-coupled.
+   Polling is the safe v1.
+5. **Ward-protected tables** — decide whether to mirror pins from tables inside someone's
+   ward (BCT respects `PrivateArea.CheckAccess`; server-side we likely just mirror all).
+6. **`ownerID` → player name** — pins carry the owner's `playerID` (long) + the pin *label*,
+   but **not** a player display name. Decide whether to resolve names (cache from connected
+   peers) or just store the `ownerID` in WebMap's `name`/`id` fields.
+
+## 10b. Verification evidence (ground truth used for this spec)
+
+All confirmed by reading decompiled `assembly_valheim` + launched mods (no guessing):
+
+- **`MapTable.cs`** (`davrum/assembly_valheim`): `OnWrite`/`OnRead` use
+  `m_nview.GetZDO().GetByteArray(ZDOVars.s_data)`, `Utils.Compress/Decompress`, and
+  `Minimap.GetSharedMapData/AddSharedMapData` → confirms storage key + compression + payload.
+- **`Minimap.GetSharedMapData` / `AddSharedMapData` / `ReadExploredArray`**
+  (`szzszzd/Learn/assembly_valheim/Minimap.cs`): confirms version `2`, single explored mask
+  (`m_explored | m_exploredOthers`), per-pin layout (`long ownerID, string name, Vector3 pos,
+  int type, bool checked`), pins **replaced** not merged, and the `HavePinInRange(pos, 1f)`
+  dedupe.
+- **AsocialCartography** (`OrianaVenture/VentureValheim`): confirms modern `AddPin` signature
+  `(Vector3, PinType, string, bool save, bool checked, long ownerID, PlatformUserID author)`,
+  that **Icon0–4 are the player-placeable pins**, and the "remember all shared pins" +
+  proximity-dedupe pattern we reuse.
+- **ServerSideMap** (`Mydayyy/Valheim-ServerSideMap`): server-side pin store + proximity-dedupe
+  (`Utils.DistanceXZ < radius`) reference — but note it relies on **client mods** (RPC upsync),
+  which is exactly what we avoid by reading the cartography ZDO instead.
+- **WebMap v2.7.1** (`h0tw1r3/valheim-webmap`): `pins.csv` line format + `MapDataServer.AddPin`
+  / `SavePins` integration target (§5).
+
+> Key ecosystem finding: **every existing "server-side map/pin" mod is actually client+server**
+> (they patch the client `Minimap` and upsync via RPC). Reading the **cartography table ZDO**
+> is the *only* genuinely client-free source of persistent in-game pins — which is why no
+> existing mod does precisely this, and why we parse the vanilla format ourselves.
+
+---
+
+## 10. Test plan
+
+1. Build, drop DLL, start server, confirm it logs "scanning N cartography tables".
+2. In-game: place a couple of map markers (Icon0/Icon3), walk to a cartography table, click
+   **write**.
+3. Within `poll_interval_seconds`, the pins appear on the web map (and in
+   `BepInEx/plugins/WebMap/map_data/<world>/pins.csv`).
+4. Write again with no new pins → **no duplicates** added (verify pins.csv line count steady).
+5. Have a second player write different pins → both players' pins coexist on the web map
+   (union accumulation works despite the table only storing the last writer).
+6. Restart server → no duplicate re-import (seen-set rebuilt from pins.csv).
+```

--- a/docs/cartography-pin-sync-spec.md
+++ b/docs/cartography-pin-sync-spec.md
@@ -66,13 +66,12 @@ const string CartographyPrefab = "piece_cartographytable";
 int prefabHash = CartographyPrefab.GetStableHashCode();
 
 var zdos = new List<ZDO>();
-// Signature varies by Valheim version — verify in assembly_valheim:
-//   ZDOMan.instance.GetAllZDOsWithPrefab(string prefab, List<ZDO> zdos)  // returns bool
-ZDOMan.instance.GetAllZDOsWithPrefab(CartographyPrefab, zdos);
+// Current Valheim only exposes the ITERATIVE form (the simple one was removed):
+//   bool GetAllZDOsWithPrefabIterative(string prefab, List<ZDO> zdos, ref int index)
+// It appends to `zdos`, does ~400 sectors per call, and returns true when complete:
+int index = 0;
+while (!ZDOMan.instance.GetAllZDOsWithPrefabIterative(CartographyPrefab, zdos, ref index)) { }
 ```
-
-If `GetAllZDOsWithPrefab` isn't available/stable in the target version, fall back to
-iterating `ZDOMan`'s object index and filtering by `zdo.GetPrefab() == prefabHash`.
 
 ### 3.2 Read the map-data byte array from the ZDO — ✅ CONFIRMED
 

--- a/mods/WebMapCartographySync/.gitignore
+++ b/mods/WebMapCartographySync/.gitignore
@@ -1,0 +1,7 @@
+# Build output
+bin/
+obj/
+
+# Reference assemblies — pulled via FTP locally or via steamcmd/Thunderstore in CI.
+# Do NOT commit: Valheim/Unity DLLs are copyrighted; WebMap/BepInEx are redistributed elsewhere.
+libs/

--- a/mods/WebMapCartographySync/README.md
+++ b/mods/WebMapCartographySync/README.md
@@ -1,0 +1,97 @@
+# WebMapCartographySync
+
+Server-only BepInEx plugin that mirrors **cartography-table pins** onto the **WebMap** web
+map. When a player writes their map to a cartography table in-game, their pins show up on the
+web map (and persist to WebMap's `pins.csv`). **No client mods. No external services.**
+
+Design + verified data format: [`../../docs/cartography-pin-sync-spec.md`](../../docs/cartography-pin-sync-spec.md).
+
+## How it works
+
+Cartography tables store their shared map data (exploration + pins) in the table's **ZDO**
+(`ZDOVars.s_data`, `Utils.Compress`'d), which the dedicated server holds. Every
+`poll_interval_seconds`, the plugin:
+
+1. finds all `piece_cartographytable` ZDOs (`ZDOMan.GetAllZDOsWithPrefab`),
+2. decompresses + parses the pin list (no `Minimap` needed — pure `ZPackage`),
+3. dedupes against pins already in WebMap (deterministic id + 1-unit proximity, mirroring
+   vanilla `HavePinInRange`),
+4. calls `MapDataServer.AddPin(...)` + `SavePins()` via reflection for each new pin.
+
+Because the table only ever stores the **last writer's** pins (verified — vanilla replaces,
+doesn't merge, pins on write), the plugin **accumulates the union** across polls.
+
+## Build
+
+Requires the .NET SDK. Point the build at your game/BepInEx assemblies:
+
+```bash
+dotnet build mods/WebMapCartographySync/WebMapCartographySync.csproj -c Release \
+  -p:VALHEIM_MANAGED="/path/to/valheim_server_Data/Managed" \
+  -p:BEPINEX_CORE="/path/to/BepInEx/core" \
+  -p:WEBMAP_DLL="/path/to/BepInEx/plugins/WebMap/WebMap.dll"
+```
+
+Output: `WebMapCartographySync.dll`. (`WEBMAP_DLL` is optional — runtime uses reflection — but
+referencing it lets the compiler resolve types if you switch to direct calls later.)
+
+> Tip: grab `assembly_valheim.dll` + `UnityEngine*.dll` from your own server (you already have
+> FTP access to `valheim_server_Data/Managed`) so the build matches the running version.
+
+## Getting the compiled DLL
+
+You don't need a local toolchain. The GitHub Actions workflow
+(`.github/workflows/build-plugin.yml`) compiles this on every push to
+`mods/WebMapCartographySync/**` (or via "Run workflow") and publishes
+`WebMapCartographySync.dll` as a build **artifact** — no copyrighted DLLs are committed; CI
+fetches Valheim via steamcmd, BepInEx via Thunderstore, WebMap via GitHub.
+
+Download it with:
+```bash
+gh run download --name WebMapCartographySync        # latest run
+```
+
+## Deploy (FTP)
+
+1. **Stop the server** (config-write-on-shutdown rule).
+2. Upload `WebMapCartographySync.dll` to
+   `198.73.57.160_27029/BepInEx/plugins/` (loose, like the other single-file mods).
+   Requires WebMap already installed (it is).
+   ```bash
+   curl --user "USER:PASS" -T WebMapCartographySync.dll \
+     "ftp://198.73.57.160:8823/198.73.57.160_27029/BepInEx/plugins/WebMapCartographySync.dll"
+   ```
+3. Start the server. Confirm in `BepInEx/LogOutput.log`:
+   - `WebMapCartographySync v0.1.0 loaded ...`
+   - `Bound to WebMap MapDataServer (...)`
+4. Edit `BepInEx/config/lol.dean.turtleheim.webmapcartographysync.cfg` **only while stopped**.
+
+## Test
+
+1. In-game: place a couple of map markers (the placeable Icon pins), go to a cartography
+   table, click **write**.
+2. Within `poll_interval_seconds`, pins appear on the web map + in
+   `BepInEx/plugins/WebMap/map_data/<world>/pins.csv`.
+3. Write again with no new pins → no duplicates (line count steady).
+4. Second player writes different pins → both coexist (union accumulation).
+5. Restart server → no duplicate re-import (dedupe primed from `pins.csv`).
+
+## Assumptions to confirm on first run (logged if wrong)
+
+These are verified against decompiled source but worth a glance after major Valheim updates:
+
+- **Map-data `version == 2`** and the field layout in `CartographyScanner.ReadPins`. If a future
+  patch bumps the version, re-check `Minimap.GetSharedMapData`.
+- **`ZDOMan.GetAllZDOsWithPrefab(string, List<ZDO>)`** signature (logs an error if it differs).
+- **`piece_cartographytable`** prefab name (configurable).
+- **WebMap reflection targets**: static `mapDataServer` field, `AddPin(6 args)`, static
+  `SavePins()`, `pins` list. The bind step logs exactly what it found/missed.
+
+## Known limitations (v1)
+
+- **Additive only** — removing/unchecking a pin in-game does not remove it from the web map.
+- **No player display-name** — the shared data carries the owner's numeric `playerID` + the pin
+  label, not a name. WebMap's `id`/`name` fields get the `ownerID` string. (Future: resolve
+  names from connected peers.)
+- Players must **actively write** to a cartography table; this is not passive pin capture
+  (that's impossible server-side — see the spec's §1).

--- a/mods/WebMapCartographySync/README.md
+++ b/mods/WebMapCartographySync/README.md
@@ -82,7 +82,8 @@ These are verified against decompiled source but worth a glance after major Valh
 
 - **Map-data `version == 2`** and the field layout in `CartographyScanner.ReadPins`. If a future
   patch bumps the version, re-check `Minimap.GetSharedMapData`.
-- **`ZDOMan.GetAllZDOsWithPrefab(string, List<ZDO>)`** signature (logs an error if it differs).
+- **`ZDOMan.GetAllZDOsWithPrefabIterative(string, List<ZDO>, ref int)`** signature — looped
+  until it returns true (logs an error if it differs).
 - **`piece_cartographytable`** prefab name (configurable).
 - **WebMap reflection targets**: static `mapDataServer` field, `AddPin(6 args)`, static
   `SavePins()`, `pins` list. The bind step logs exactly what it found/missed.

--- a/mods/WebMapCartographySync/WebMapCartographySync.csproj
+++ b/mods/WebMapCartographySync/WebMapCartographySync.csproj
@@ -1,0 +1,70 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Server-side BepInEx plugin: mirrors cartography-table pins into WebMap.
+    See ../../docs/cartography-pin-sync-spec.md for the design + verified format.
+
+    Build prerequisites (set these as env vars or pass via -p:):
+      VALHEIM_MANAGED = path to .../valheim_server_Data/Managed   (game assemblies)
+      BEPINEX_CORE    = path to .../BepInEx/core                  (BepInEx + 0Harmony)
+      WEBMAP_DLL      = full path to the deployed WebMap.dll       (for AddPin/SavePins types)
+
+    We reference WebMap.dll only so the project resolves; at runtime we reach WebMap
+    through reflection (WebMapBridge.cs) so a version mismatch degrades gracefully
+    instead of failing to load.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyName>WebMapCartographySync</AssemblyName>
+    <Version>0.1.0</Version>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+
+    <!-- Default all reference paths to the local libs/ folder (populated by FTP pull or CI).
+         Override any of them on the command line: -p:VALHEIM_MANAGED=... etc. -->
+    <LibsDir>$(MSBuildProjectDirectory)/libs</LibsDir>
+    <VALHEIM_MANAGED Condition="'$(VALHEIM_MANAGED)' == ''">$(LibsDir)</VALHEIM_MANAGED>
+    <BEPINEX_CORE Condition="'$(BEPINEX_CORE)' == ''">$(LibsDir)</BEPINEX_CORE>
+    <WEBMAP_DLL Condition="'$(WEBMAP_DLL)' == ''">$(LibsDir)/WebMap.dll</WEBMAP_DLL>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- BepInEx + Harmony (from your BepInEx/core folder) -->
+    <Reference Include="BepInEx">
+      <HintPath>$(BEPINEX_CORE)\BepInEx.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(BEPINEX_CORE)\0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+
+    <!-- Valheim + Unity (from valheim_server_Data/Managed) -->
+    <Reference Include="assembly_valheim">
+      <HintPath>$(VALHEIM_MANAGED)\assembly_valheim.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="assembly_utils">
+      <HintPath>$(VALHEIM_MANAGED)\assembly_utils.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>$(VALHEIM_MANAGED)\UnityEngine.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(VALHEIM_MANAGED)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+
+    <!-- WebMap (deployed plugin DLL) — referenced for convenience; runtime uses reflection -->
+    <Reference Include="WebMap" Condition="'$(WEBMAP_DLL)' != ''">
+      <HintPath>$(WEBMAP_DLL)</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/mods/WebMapCartographySync/manifest.json
+++ b/mods/WebMapCartographySync/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "WebMapCartographySync",
+  "version_number": "0.1.0",
+  "website_url": "https://github.com/JollyGrin/map-iframe",
+  "description": "Server-side: mirrors cartography-table pins onto the WebMap web map. No client mods needed.",
+  "dependencies": [
+    "denikson-BepInExPack_Valheim-5.4.2202"
+  ]
+}

--- a/mods/WebMapCartographySync/src/CartographyScanner.cs
+++ b/mods/WebMapCartographySync/src/CartographyScanner.cs
@@ -175,6 +175,8 @@ namespace WebMapCartographySync
                     Vector3 vpos = pkg.ReadVector3();
                     var type = (Minimap.PinType)pkg.ReadInt();
                     bool isChecked = pkg.ReadBool();
+                    // v3 (current Valheim) adds a per-pin author = PlatformUserID.ToString()
+                    if (version >= 3) pkg.ReadString();
                     pins.Add(new ParsedPin(ownerId, name, vpos, type, isChecked));
                     Plugin.Log.LogInfo($"  pin[{i}] type={type} pos=({vpos.x:F0},{vpos.z:F0}) text='{name}' owner={ownerId}");
                 }

--- a/mods/WebMapCartographySync/src/CartographyScanner.cs
+++ b/mods/WebMapCartographySync/src/CartographyScanner.cs
@@ -96,12 +96,17 @@ namespace WebMapCartographySync
             var result = new List<ZDO>();
             try
             {
-                // Signature in current Valheim: bool GetAllZDOsWithPrefab(string prefab, List<ZDO> zdos)
-                ZDOMan.instance.GetAllZDOsWithPrefab(_config.CartographyPrefab.Value, result);
+                // Current Valheim only exposes the iterative form. It appends matches to `result`,
+                // processes ~400 sectors per call, advances `index`, and returns true when complete.
+                int index = 0;
+                while (!ZDOMan.instance.GetAllZDOsWithPrefabIterative(_config.CartographyPrefab.Value, result, ref index))
+                {
+                    // keep going until it reports done
+                }
             }
             catch (Exception ex)
             {
-                Plugin.Log.LogError($"GetAllZDOsWithPrefab failed (signature mismatch?): {ex.Message}");
+                Plugin.Log.LogError($"GetAllZDOsWithPrefabIterative failed (signature mismatch?): {ex.Message}");
             }
             return result;
         }

--- a/mods/WebMapCartographySync/src/CartographyScanner.cs
+++ b/mods/WebMapCartographySync/src/CartographyScanner.cs
@@ -93,7 +93,11 @@ namespace WebMapCartographySync
                 }
             }
 
-            Plugin.Log.LogInfo($"Scan: {zdos.Count} table(s), {parsedTotal} pin(s) parsed, {added} new mirrored.");
+            if (added > 0)
+                Plugin.Log.LogInfo($"Mirrored {added} new cartography pin(s) to WebMap " +
+                                   $"({zdos.Count} table(s), {parsedTotal} parsed).");
+            else if (_config.VerboseLogging.Value)
+                Plugin.Log.LogInfo($"Scan: {zdos.Count} table(s), {parsedTotal} pin(s) parsed, 0 new.");
 
             if (added > 0) WebMapBridge.SavePins();
         }
@@ -137,8 +141,9 @@ namespace WebMapCartographySync
                 long total = data.Length;
                 long afterExplored = 8L + (long)exploredLength;
 
-                Plugin.Log.LogInfo($"cart parse: total={total}B version={version} exploredLength={exploredLength} " +
-                                   $"(explored should end at {afterExplored})");
+                if (_config.VerboseLogging.Value)
+                    Plugin.Log.LogInfo($"cart parse: total={total}B version={version} exploredLength={exploredLength} " +
+                                       $"(explored should end at {afterExplored})");
 
                 // If the explored block doesn't fit, our format assumption is wrong for this game
                 // version. Dump head+tail so we can decode the real layout.
@@ -166,7 +171,7 @@ namespace WebMapCartographySync
                     Plugin.Log.LogWarning($"Implausible numPins={numPins}; tail96={HexTail(data, 96)}");
                     return pins;
                 }
-                Plugin.Log.LogInfo($"cart parse: numPins={numPins}");
+                if (_config.VerboseLogging.Value) Plugin.Log.LogInfo($"cart parse: numPins={numPins}");
 
                 for (int i = 0; i < numPins; i++)
                 {
@@ -178,7 +183,8 @@ namespace WebMapCartographySync
                     // v3 (current Valheim) adds a per-pin author = PlatformUserID.ToString()
                     if (version >= 3) pkg.ReadString();
                     pins.Add(new ParsedPin(ownerId, name, vpos, type, isChecked));
-                    Plugin.Log.LogInfo($"  pin[{i}] type={type} pos=({vpos.x:F0},{vpos.z:F0}) text='{name}' owner={ownerId}");
+                    if (_config.VerboseLogging.Value)
+                        Plugin.Log.LogInfo($"  pin[{i}] type={type} pos=({vpos.x:F0},{vpos.z:F0}) text='{name}' owner={ownerId}");
                 }
             }
             catch (Exception ex)

--- a/mods/WebMapCartographySync/src/CartographyScanner.cs
+++ b/mods/WebMapCartographySync/src/CartographyScanner.cs
@@ -57,38 +57,45 @@ namespace WebMapCartographySync
             if (zdos.Count == 0) return;
 
             int added = 0;
+            int parsedTotal = 0;
             foreach (var zdo in zdos)
             {
-                foreach (var pin in ReadPins(zdo))
+                try
                 {
-                    if (!_config.ShouldMirror(pin.Type)) continue;
+                    var pins = ReadPins(zdo);
+                    parsedTotal += pins.Count;
+                    foreach (var pin in pins)
+                    {
+                        if (!_config.ShouldMirror(pin.Type)) continue;
 
-                    string key = _dedup.KeyFor(pin, _config.IncludeOwnerInKey.Value, _config.DedupeRadius.Value);
-                    if (_dedup.SeenOrTooClose(pin, key, _config.DedupeRadius.Value)) continue;
+                        string key = _dedup.KeyFor(pin, _config.IncludeOwnerInKey.Value, _config.DedupeRadius.Value);
+                        if (_dedup.SeenOrTooClose(pin, key, _config.DedupeRadius.Value)) continue;
 
-                    string pinId = StableId.From(key);
-                    string webType = _typeMap.TryGetValue(pin.Type, out var t) ? t : _config.MapDefault.Value;
-                    string ownerStr = pin.OwnerId.ToString();
+                        string pinId = StableId.From(key);
+                        string webType = _typeMap.TryGetValue(pin.Type, out var t) ? t : _config.MapDefault.Value;
+                        string ownerStr = pin.OwnerId.ToString();
 
-                    WebMapBridge.AddPin(
-                        id: ownerStr,
-                        pinId: pinId,
-                        type: webType,
-                        name: ownerStr,          // no player display-name in the data; see README
-                        position: pin.Pos,
-                        pinText: pin.Label);
+                        WebMapBridge.AddPin(
+                            id: ownerStr,
+                            pinId: pinId,
+                            type: webType,
+                            name: ownerStr,          // no player display-name in the data; see README
+                            position: pin.Pos,
+                            pinText: pin.Label);
 
-                    _dedup.Remember(pin, pinId);
-                    added++;
+                        _dedup.Remember(pin, pinId);
+                        added++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Plugin.Log.LogWarning($"Processing a cartography table failed: {ex.Message}");
                 }
             }
 
-            if (added > 0)
-            {
-                WebMapBridge.SavePins();
-                Plugin.Log.LogInfo($"Mirrored {added} new cartography pin(s) to WebMap " +
-                                   $"(scanned {zdos.Count} table(s)).");
-            }
+            Plugin.Log.LogInfo($"Scan: {zdos.Count} table(s), {parsedTotal} pin(s) parsed, {added} new mirrored.");
+
+            if (added > 0) WebMapBridge.SavePins();
         }
 
         private List<ZDO> FindCartographyZdos()
@@ -111,38 +118,73 @@ namespace WebMapCartographySync
             return result;
         }
 
-        private IEnumerable<ParsedPin> ReadPins(ZDO zdo)
+        private List<ParsedPin> ReadPins(ZDO zdo)
         {
+            var pins = new List<ParsedPin>();
+
             byte[] raw = zdo.GetByteArray(ZDOVars.s_data);
-            if (raw == null || raw.Length == 0) yield break;
+            if (raw == null || raw.Length == 0) return pins;
 
             byte[] data;
             try { data = Utils.Decompress(raw); }
-            catch (Exception ex) { Plugin.Log.LogWarning($"Decompress failed for a table ZDO: {ex.Message}"); yield break; }
+            catch (Exception ex) { Plugin.Log.LogWarning($"Decompress failed: {ex.Message}"); return pins; }
 
-            var pkg = new ZPackage(data);
-
-            int version = pkg.ReadInt();
-            int exploredLength = pkg.ReadInt();
-            if (exploredLength < 0 || exploredLength > 64 * 1024 * 1024)
+            try
             {
-                Plugin.Log.LogWarning($"Implausible exploredLength {exploredLength}; skipping table.");
-                yield break;
+                var pkg = new ZPackage(data);
+                int version = pkg.ReadInt();
+                int exploredLength = pkg.ReadInt();
+                long total = data.Length;
+                long afterExplored = 8L + (long)exploredLength;
+
+                Plugin.Log.LogInfo($"cart parse: total={total}B version={version} exploredLength={exploredLength} " +
+                                   $"(explored should end at {afterExplored})");
+
+                // If the explored block doesn't fit, our format assumption is wrong for this game
+                // version. Dump head+tail so we can decode the real layout.
+                if (exploredLength < 0 || afterExplored + 4 > total)
+                {
+                    Plugin.Log.LogWarning(
+                        $"Format mismatch: explored end {afterExplored} + 4 > total {total}. " +
+                        $"head16={Hex(data, 0, 16)} tail96={HexTail(data, 96)}");
+                    return pins;
+                }
+
+                SkipBytes(pkg, exploredLength);
+                long pos = StreamPos(pkg);
+                if (pos != afterExplored)
+                {
+                    Plugin.Log.LogWarning($"skip landed at {pos}, expected {afterExplored}; correcting.");
+                    SetStreamPos(pkg, afterExplored);
+                }
+
+                if (version < 2) return pins;
+
+                int numPins = pkg.ReadInt();
+                if (numPins < 0 || numPins > 100000)
+                {
+                    Plugin.Log.LogWarning($"Implausible numPins={numPins}; tail96={HexTail(data, 96)}");
+                    return pins;
+                }
+                Plugin.Log.LogInfo($"cart parse: numPins={numPins}");
+
+                for (int i = 0; i < numPins; i++)
+                {
+                    long ownerId = pkg.ReadLong();
+                    string name = pkg.ReadString();
+                    Vector3 vpos = pkg.ReadVector3();
+                    var type = (Minimap.PinType)pkg.ReadInt();
+                    bool isChecked = pkg.ReadBool();
+                    pins.Add(new ParsedPin(ownerId, name, vpos, type, isChecked));
+                    Plugin.Log.LogInfo($"  pin[{i}] type={type} pos=({vpos.x:F0},{vpos.z:F0}) text='{name}' owner={ownerId}");
+                }
             }
-            SkipBytes(pkg, exploredLength); // each bool == 1 byte
-
-            if (version < 2) yield break;   // pins only exist from version 2
-
-            int numPins = pkg.ReadInt();
-            for (int i = 0; i < numPins; i++)
+            catch (Exception ex)
             {
-                long ownerId = pkg.ReadLong();
-                string name = pkg.ReadString();
-                Vector3 pos = pkg.ReadVector3();
-                var type = (Minimap.PinType)pkg.ReadInt();
-                bool isChecked = pkg.ReadBool();
-                yield return new ParsedPin(ownerId, name, pos, type, isChecked);
+                Plugin.Log.LogWarning($"Pin parse aborted: {ex.Message}");
             }
+
+            return pins;
         }
 
         /// <summary>Advance the ZPackage reader by <paramref name="count"/> bytes (O(1) seek, byte-loop fallback).</summary>
@@ -159,5 +201,27 @@ namespace WebMapCartographySync
                 for (int i = 0; i < count; i++) pkg.ReadByte();
             }
         }
+
+        private static long StreamPos(ZPackage pkg)
+        {
+            try { return ((BinaryReader)ZPackageReaderField.GetValue(pkg)).BaseStream.Position; }
+            catch { return -1; }
+        }
+
+        private static void SetStreamPos(ZPackage pkg, long pos)
+        {
+            try { ((BinaryReader)ZPackageReaderField.GetValue(pkg)).BaseStream.Position = pos; }
+            catch { }
+        }
+
+        private static string Hex(byte[] d, int off, int len)
+        {
+            int end = Math.Min(off + len, d.Length);
+            var sb = new System.Text.StringBuilder();
+            for (int i = Math.Max(0, off); i < end; i++) sb.Append(d[i].ToString("x2"));
+            return sb.ToString();
+        }
+
+        private static string HexTail(byte[] d, int len) => Hex(d, Math.Max(0, d.Length - len), len);
     }
 }

--- a/mods/WebMapCartographySync/src/CartographyScanner.cs
+++ b/mods/WebMapCartographySync/src/CartographyScanner.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// Finds cartography-table ZDOs, decodes the shared-map blob, extracts pins,
+    /// dedupes against what WebMap already has, and pushes new ones in.
+    ///
+    /// Format (verified against decompiled Minimap.GetSharedMapData, version 2):
+    ///   ZDO byte[] under ZDOVars.s_data, Utils.Compress'd. Decompressed ZPackage =
+    ///     int version(=2)
+    ///     int exploredLength            // == textureSize*textureSize
+    ///     bool[exploredLength]          // skipped
+    ///     int numPins
+    ///     repeat: long ownerID, string name, Vector3 pos, int type, bool checked
+    /// </summary>
+    public class CartographyScanner
+    {
+        private readonly PluginConfig _config;
+        private readonly Dedup _dedup = new Dedup();
+        private readonly Dictionary<Minimap.PinType, string> _typeMap;
+        private bool _seenSetPrimed;
+
+        // Cached reflection handle for ZPackage's internal BinaryReader (for O(1) skip).
+        private static readonly FieldInfo ZPackageReaderField =
+            typeof(ZPackage).GetField("m_reader", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public CartographyScanner(PluginConfig config)
+        {
+            _config = config;
+            _typeMap = config.BuildTypeMap();
+        }
+
+        public void ScanOnce()
+        {
+            if (!WebMapBridge.IsReady)
+            {
+                if (!WebMapBridge.TryBind())
+                {
+                    Plugin.Log.LogWarning("WebMap not found yet (MapDataServer unresolved); skipping scan.");
+                    return;
+                }
+            }
+
+            // Prime the dedupe set once from WebMap's existing pins (survives restarts via pins.csv).
+            if (!_seenSetPrimed)
+            {
+                _dedup.PrimeFromExisting(WebMapBridge.GetExistingPinIds());
+                _seenSetPrimed = true;
+            }
+
+            var zdos = FindCartographyZdos();
+            if (zdos.Count == 0) return;
+
+            int added = 0;
+            foreach (var zdo in zdos)
+            {
+                foreach (var pin in ReadPins(zdo))
+                {
+                    if (!_config.ShouldMirror(pin.Type)) continue;
+
+                    string key = _dedup.KeyFor(pin, _config.IncludeOwnerInKey.Value, _config.DedupeRadius.Value);
+                    if (_dedup.SeenOrTooClose(pin, key, _config.DedupeRadius.Value)) continue;
+
+                    string pinId = StableId.From(key);
+                    string webType = _typeMap.TryGetValue(pin.Type, out var t) ? t : _config.MapDefault.Value;
+                    string ownerStr = pin.OwnerId.ToString();
+
+                    WebMapBridge.AddPin(
+                        id: ownerStr,
+                        pinId: pinId,
+                        type: webType,
+                        name: ownerStr,          // no player display-name in the data; see README
+                        position: pin.Pos,
+                        pinText: pin.Label);
+
+                    _dedup.Remember(pin, pinId);
+                    added++;
+                }
+            }
+
+            if (added > 0)
+            {
+                WebMapBridge.SavePins();
+                Plugin.Log.LogInfo($"Mirrored {added} new cartography pin(s) to WebMap " +
+                                   $"(scanned {zdos.Count} table(s)).");
+            }
+        }
+
+        private List<ZDO> FindCartographyZdos()
+        {
+            var result = new List<ZDO>();
+            try
+            {
+                // Signature in current Valheim: bool GetAllZDOsWithPrefab(string prefab, List<ZDO> zdos)
+                ZDOMan.instance.GetAllZDOsWithPrefab(_config.CartographyPrefab.Value, result);
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.LogError($"GetAllZDOsWithPrefab failed (signature mismatch?): {ex.Message}");
+            }
+            return result;
+        }
+
+        private IEnumerable<ParsedPin> ReadPins(ZDO zdo)
+        {
+            byte[] raw = zdo.GetByteArray(ZDOVars.s_data);
+            if (raw == null || raw.Length == 0) yield break;
+
+            byte[] data;
+            try { data = Utils.Decompress(raw); }
+            catch (Exception ex) { Plugin.Log.LogWarning($"Decompress failed for a table ZDO: {ex.Message}"); yield break; }
+
+            var pkg = new ZPackage(data);
+
+            int version = pkg.ReadInt();
+            int exploredLength = pkg.ReadInt();
+            if (exploredLength < 0 || exploredLength > 64 * 1024 * 1024)
+            {
+                Plugin.Log.LogWarning($"Implausible exploredLength {exploredLength}; skipping table.");
+                yield break;
+            }
+            SkipBytes(pkg, exploredLength); // each bool == 1 byte
+
+            if (version < 2) yield break;   // pins only exist from version 2
+
+            int numPins = pkg.ReadInt();
+            for (int i = 0; i < numPins; i++)
+            {
+                long ownerId = pkg.ReadLong();
+                string name = pkg.ReadString();
+                Vector3 pos = pkg.ReadVector3();
+                var type = (Minimap.PinType)pkg.ReadInt();
+                bool isChecked = pkg.ReadBool();
+                yield return new ParsedPin(ownerId, name, pos, type, isChecked);
+            }
+        }
+
+        /// <summary>Advance the ZPackage reader by <paramref name="count"/> bytes (O(1) seek, byte-loop fallback).</summary>
+        private static void SkipBytes(ZPackage pkg, int count)
+        {
+            if (count <= 0) return;
+            try
+            {
+                var reader = (BinaryReader)ZPackageReaderField.GetValue(pkg);
+                reader.BaseStream.Seek(count, SeekOrigin.Current);
+            }
+            catch
+            {
+                for (int i = 0; i < count; i++) pkg.ReadByte();
+            }
+        }
+    }
+}

--- a/mods/WebMapCartographySync/src/Dedup.cs
+++ b/mods/WebMapCartographySync/src/Dedup.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// Prevents re-posting pins. Two layers:
+    ///   1. Deterministic pinId set (idempotent across restarts — primed from WebMap's pins.csv).
+    ///   2. Proximity check mirroring vanilla HavePinInRange(pos, radius) so jittered re-writes
+    ///      of "the same" pin don't pile up.
+    /// </summary>
+    public class Dedup
+    {
+        private readonly HashSet<string> _seenPinIds = new HashSet<string>();
+        // Accepted pins by webmap type bucket -> positions, for proximity dedupe.
+        private readonly Dictionary<string, List<Vector2>> _accepted = new Dictionary<string, List<Vector2>>();
+
+        public void PrimeFromExisting(IEnumerable<string> existingPinIds)
+        {
+            foreach (var id in existingPinIds)
+                if (!string.IsNullOrEmpty(id)) _seenPinIds.Add(id);
+        }
+
+        /// <summary>Stable dedupe key: type + rounded coords (+ owner if configured) + label.</summary>
+        public string KeyFor(ParsedPin pin, bool includeOwner, float radius)
+        {
+            // Round to the dedupe radius grid so near-identical coords collapse to one key.
+            float grid = Mathf.Max(0.01f, radius);
+            long gx = (long)Mathf.Round(pin.Pos.x / grid);
+            long gz = (long)Mathf.Round(pin.Pos.z / grid);
+            string owner = includeOwner ? pin.OwnerId.ToString() : "_";
+            return string.Format(CultureInfo.InvariantCulture,
+                "{0}|{1}|{2}|{3}|{4}", owner, (int)pin.Type, gx, gz, pin.Label);
+        }
+
+        /// <summary>True if we've already posted this pin (by id) or one within radius of same type.</summary>
+        public bool SeenOrTooClose(ParsedPin pin, string key, float radius)
+        {
+            if (_seenPinIds.Contains(StableId.From(key))) return true;
+
+            string bucket = ((int)pin.Type).ToString();
+            if (_accepted.TryGetValue(bucket, out var list))
+            {
+                var p = new Vector2(pin.Pos.x, pin.Pos.z);
+                float r2 = radius * radius;
+                foreach (var q in list)
+                    if ((q - p).sqrMagnitude < r2) return true;
+            }
+            return false;
+        }
+
+        public void Remember(ParsedPin pin, string pinId)
+        {
+            _seenPinIds.Add(pinId);
+            string bucket = ((int)pin.Type).ToString();
+            if (!_accepted.TryGetValue(bucket, out var list))
+                _accepted[bucket] = list = new List<Vector2>();
+            list.Add(new Vector2(pin.Pos.x, pin.Pos.z));
+        }
+    }
+
+    /// <summary>Deterministic, stable id from a string (FNV-1a 64-bit, hex). Same input -> same id forever.</summary>
+    public static class StableId
+    {
+        public static string From(string s)
+        {
+            const ulong offset = 14695981039346656037UL;
+            const ulong prime = 1099511628211UL;
+            ulong hash = offset;
+            foreach (char c in s)
+            {
+                hash ^= c;
+                hash *= prime;
+            }
+            return "cart" + hash.ToString("x16");
+        }
+    }
+}

--- a/mods/WebMapCartographySync/src/ParsedPin.cs
+++ b/mods/WebMapCartographySync/src/ParsedPin.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// One pin as read out of a cartography table's shared-map data.
+    /// Field order matches Minimap.GetSharedMapData (verified, map-data version 2):
+    ///   long ownerID, string name(label), Vector3 pos, int type, bool checked
+    /// </summary>
+    public readonly struct ParsedPin
+    {
+        public readonly long OwnerId;
+        public readonly string Label;       // the pin's text (Minimap.PinData.m_name)
+        public readonly Vector3 Pos;        // world pos; only x,z used by WebMap
+        public readonly Minimap.PinType Type;
+        public readonly bool Checked;
+
+        public ParsedPin(long ownerId, string label, Vector3 pos, Minimap.PinType type, bool isChecked)
+        {
+            OwnerId = ownerId;
+            Label = label ?? "";
+            Pos = pos;
+            Type = type;
+            Checked = isChecked;
+        }
+    }
+}

--- a/mods/WebMapCartographySync/src/Plugin.cs
+++ b/mods/WebMapCartographySync/src/Plugin.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using BepInEx;
+using BepInEx.Logging;
+using UnityEngine;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// Server-only BepInEx plugin. Periodically scans every cartography table's ZDO,
+    /// extracts the pins players have written to it, and mirrors NEW ones into WebMap
+    /// (which persists to pins.csv + broadcasts live over WebSocket).
+    ///
+    /// No client mods, no external services. See docs/cartography-pin-sync-spec.md.
+    /// </summary>
+    [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
+    public class Plugin : BaseUnityPlugin
+    {
+        public const string PluginGuid = "lol.dean.turtleheim.webmapcartographysync";
+        public const string PluginName = "WebMapCartographySync";
+        public const string PluginVersion = "0.1.0";
+
+        internal static ManualLogSource Log;
+        private PluginConfig _config;
+        private CartographyScanner _scanner;
+
+        private void Awake()
+        {
+            Log = Logger;
+            _config = new PluginConfig(Config);
+
+            if (!_config.Enabled.Value)
+            {
+                Log.LogInfo($"{PluginName} disabled via config.");
+                return;
+            }
+
+            _scanner = new CartographyScanner(_config);
+            StartCoroutine(PollLoop());
+            Log.LogInfo($"{PluginName} v{PluginVersion} loaded; will scan cartography tables every " +
+                        $"{_config.PollIntervalSeconds.Value}s once the server is up.");
+        }
+
+        private IEnumerator PollLoop()
+        {
+            // Wait until the world/networking is actually running.
+            while (ZNet.instance == null || ZDOMan.instance == null)
+                yield return new WaitForSeconds(2f);
+
+            // Only act as the authoritative server (dedicated or host). Pure clients do nothing.
+            for (; ; )
+            {
+                if (ZNet.instance != null && ZNet.instance.IsServer() && ZDOMan.instance != null)
+                {
+                    try
+                    {
+                        _scanner.ScanOnce();
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Log.LogError($"Scan failed: {ex}");
+                    }
+                }
+
+                yield return new WaitForSeconds(Mathf.Max(5f, _config.PollIntervalSeconds.Value));
+            }
+        }
+    }
+}

--- a/mods/WebMapCartographySync/src/PluginConfig.cs
+++ b/mods/WebMapCartographySync/src/PluginConfig.cs
@@ -10,6 +10,7 @@ namespace WebMapCartographySync
     public class PluginConfig
     {
         public readonly ConfigEntry<bool> Enabled;
+        public readonly ConfigEntry<bool> VerboseLogging;
         public readonly ConfigEntry<float> PollIntervalSeconds;
         public readonly ConfigEntry<float> DedupeRadius;
         public readonly ConfigEntry<bool> IncludeOwnerInKey;
@@ -28,6 +29,8 @@ namespace WebMapCartographySync
         {
             Enabled = cfg.Bind("General", "enabled", true,
                 "Master switch for the cartography -> WebMap pin sync.");
+            VerboseLogging = cfg.Bind("General", "verbose_logging", false,
+                "Log per-scan parse details and every pin found (noisy). Warnings/errors always log.");
             PollIntervalSeconds = cfg.Bind("General", "poll_interval_seconds", 30f,
                 "How often (seconds) to scan cartography tables. Min 5.");
             CartographyPrefab = cfg.Bind("General", "cartography_prefab", "piece_cartographytable",

--- a/mods/WebMapCartographySync/src/PluginConfig.cs
+++ b/mods/WebMapCartographySync/src/PluginConfig.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using BepInEx.Configuration;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// All tunables, written to BepInEx/config/<guid>.cfg on first run.
+    /// Remember: edit config with the server STOPPED (BepInEx rewrites it on shutdown).
+    /// </summary>
+    public class PluginConfig
+    {
+        public readonly ConfigEntry<bool> Enabled;
+        public readonly ConfigEntry<float> PollIntervalSeconds;
+        public readonly ConfigEntry<float> DedupeRadius;
+        public readonly ConfigEntry<bool> IncludeOwnerInKey;
+        public readonly ConfigEntry<bool> MirrorBossPins;
+        public readonly ConfigEntry<string> CartographyPrefab;
+
+        // Minimap.PinType -> WebMap type string. Defaults map the 5 player-placeable icons.
+        public readonly ConfigEntry<string> MapIcon0;
+        public readonly ConfigEntry<string> MapIcon1;
+        public readonly ConfigEntry<string> MapIcon2;
+        public readonly ConfigEntry<string> MapIcon3;
+        public readonly ConfigEntry<string> MapIcon4;
+        public readonly ConfigEntry<string> MapDefault;
+
+        public PluginConfig(ConfigFile cfg)
+        {
+            Enabled = cfg.Bind("General", "enabled", true,
+                "Master switch for the cartography -> WebMap pin sync.");
+            PollIntervalSeconds = cfg.Bind("General", "poll_interval_seconds", 30f,
+                "How often (seconds) to scan cartography tables. Min 5.");
+            CartographyPrefab = cfg.Bind("General", "cartography_prefab", "piece_cartographytable",
+                "Prefab name of the cartography table (only change if a future update renames it).");
+
+            DedupeRadius = cfg.Bind("Dedupe", "dedupe_radius", 1f,
+                "Two pins of the same type within this distance (world units) are treated as the " +
+                "same pin and not re-posted. Mirrors vanilla HavePinInRange(pos, 1f).");
+            IncludeOwnerInKey = cfg.Bind("Dedupe", "include_owner_in_key", false,
+                "If true, the same spot pinned by two different players yields two web pins. " +
+                "If false (default), one pin per location regardless of who placed it.");
+
+            MirrorBossPins = cfg.Bind("Filter", "mirror_boss_pins", false,
+                "Also mirror Boss pins (Icon types are always mirrored).");
+
+            MapIcon0 = cfg.Bind("Mapping", "icon0", "dot", "WebMap type for Minimap.PinType.Icon0");
+            MapIcon1 = cfg.Bind("Mapping", "icon1", "fire", "WebMap type for Minimap.PinType.Icon1");
+            MapIcon2 = cfg.Bind("Mapping", "icon2", "mine", "WebMap type for Minimap.PinType.Icon2");
+            MapIcon3 = cfg.Bind("Mapping", "icon3", "house", "WebMap type for Minimap.PinType.Icon3");
+            MapIcon4 = cfg.Bind("Mapping", "icon4", "cave", "WebMap type for Minimap.PinType.Icon4");
+            MapDefault = cfg.Bind("Mapping", "default", "dot",
+                "WebMap type for any other mirrored pin type.");
+        }
+
+        /// <summary>Build the live PinType -> WebMap-type map from config.</summary>
+        public Dictionary<Minimap.PinType, string> BuildTypeMap()
+        {
+            return new Dictionary<Minimap.PinType, string>
+            {
+                { Minimap.PinType.Icon0, MapIcon0.Value },
+                { Minimap.PinType.Icon1, MapIcon1.Value },
+                { Minimap.PinType.Icon2, MapIcon2.Value },
+                { Minimap.PinType.Icon3, MapIcon3.Value },
+                { Minimap.PinType.Icon4, MapIcon4.Value },
+            };
+        }
+
+        /// <summary>Which pin types we mirror at all.</summary>
+        public bool ShouldMirror(Minimap.PinType type)
+        {
+            switch (type)
+            {
+                case Minimap.PinType.Icon0:
+                case Minimap.PinType.Icon1:
+                case Minimap.PinType.Icon2:
+                case Minimap.PinType.Icon3:
+                case Minimap.PinType.Icon4:
+                    return true;
+                case Minimap.PinType.Boss:
+                    return MirrorBossPins.Value;
+                default:
+                    return false; // skip Death, Player, Shout, Ping, Bonfire, etc.
+            }
+        }
+    }
+}

--- a/mods/WebMapCartographySync/src/WebMapBridge.cs
+++ b/mods/WebMapCartographySync/src/WebMapBridge.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace WebMapCartographySync
+{
+    /// <summary>
+    /// Reflection bridge into the WebMap plugin (loaded in the same process). We avoid a hard
+    /// compile-time dependency so a WebMap version change degrades to a logged warning instead
+    /// of a load failure.
+    ///
+    /// Targets (from WebMap v2.7.1 source):
+    ///   - a static field `mapDataServer` (instance of MapDataServer) on a WebMap type
+    ///   - MapDataServer.AddPin(string id, string pinId, string type, string name, Vector3 pos, string pinText)
+    ///   - MapDataServer.pins  : List&lt;string&gt;  (CSV lines: id,pinId,type,name,x,z,text)
+    ///   - a static SavePins()  on a WebMap type
+    /// </summary>
+    public static class WebMapBridge
+    {
+        private static object _mapDataServer;
+        private static MethodInfo _addPin;
+        private static MethodInfo _savePins;
+        private static FieldInfo _pinsField;
+
+        public static bool IsReady => _mapDataServer != null && _addPin != null;
+
+        public static bool TryBind()
+        {
+            try
+            {
+                var asm = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => a.GetName().Name.Equals("WebMap", StringComparison.OrdinalIgnoreCase));
+                if (asm == null) return false;
+
+                var types = asm.GetTypes();
+
+                // 1) Find the static `mapDataServer` field (the live MapDataServer instance).
+                foreach (var t in types)
+                {
+                    var f = t.GetField("mapDataServer",
+                        BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (f != null)
+                    {
+                        _mapDataServer = f.GetValue(null);
+                        if (_mapDataServer != null) break;
+                    }
+                }
+                if (_mapDataServer == null) return false;
+
+                var mdsType = _mapDataServer.GetType();
+
+                // 2) AddPin(string,string,string,string,Vector3,string)
+                _addPin = mdsType.GetMethod("AddPin", new[]
+                {
+                    typeof(string), typeof(string), typeof(string), typeof(string),
+                    typeof(Vector3), typeof(string)
+                });
+
+                // 3) pins : List<string>
+                _pinsField = mdsType.GetField("pins",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+                // 4) static SavePins() somewhere in the WebMap assembly
+                foreach (var t in types)
+                {
+                    var m = t.GetMethod("SavePins",
+                        BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                        null, Type.EmptyTypes, null);
+                    if (m != null) { _savePins = m; break; }
+                }
+
+                if (_addPin == null)
+                {
+                    Plugin.Log.LogError("Bound MapDataServer but AddPin(6-arg) not found — WebMap API changed?");
+                    return false;
+                }
+
+                Plugin.Log.LogInfo($"Bound to WebMap MapDataServer ({mdsType.FullName}). " +
+                                   $"SavePins {( _savePins != null ? "found" : "MISSING")}, " +
+                                   $"pins field {( _pinsField != null ? "found" : "MISSING")}.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.LogError($"WebMap bind failed: {ex}");
+                return false;
+            }
+        }
+
+        public static void AddPin(string id, string pinId, string type, string name, Vector3 position, string pinText)
+        {
+            _addPin.Invoke(_mapDataServer, new object[] { id, pinId, type, name, position, pinText });
+        }
+
+        public static void SavePins()
+        {
+            try { _savePins?.Invoke(null, null); }
+            catch (Exception ex) { Plugin.Log.LogWarning($"SavePins invoke failed: {ex.Message}"); }
+        }
+
+        /// <summary>Extract the pinId column (index 1) from WebMap's current pins to prime dedupe.</summary>
+        public static IEnumerable<string> GetExistingPinIds()
+        {
+            if (_pinsField?.GetValue(_mapDataServer) is List<string> lines)
+            {
+                foreach (var line in lines)
+                {
+                    if (string.IsNullOrEmpty(line)) continue;
+                    var parts = line.Split(',');
+                    if (parts.Length > 1) yield return parts[1];
+                }
+            }
+        }
+    }
+}

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -2,6 +2,10 @@
 	import { onMount } from 'svelte';
 	import { useRegister, type RegisterRequest, type UserDTO } from '$lib/api/user';
 	import { writable } from 'svelte/store';
+	import ModalMods from '$lib/modal/ModalMods.svelte';
+
+	// "How to join" mods panel
+	let isModsOpen = $state(false);
 
 	// Store for current user
 	const currentUser = writable<UserDTO | null>(null);
@@ -153,6 +157,10 @@
 		<span class="rounded-full bg-slate-950 px-2 py-1 font-mono text-xs"
 			>valheim.dean.lol:27029
 		</span>
+		<button
+			class="rounded-full bg-sky-600 px-3 py-1 text-xs hover:bg-sky-500"
+			onclick={() => (isModsOpen = true)}>How to join</button
+		>
 	</div>
 
 	{#if $currentUser}
@@ -214,6 +222,10 @@
 		</button>
 	{/if}
 </nav>
+
+{#if isModsOpen}
+	<ModalMods onClose={() => (isModsOpen = false)} />
+{/if}
 
 <style>
 	input {

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -149,7 +149,7 @@
 
 <nav class="hidden h-[50px] items-center justify-between bg-slate-900 p-2 text-white sm:flex">
 	<div class="flex gap-2">
-		<span>Valheim Server: Forest of Grins</span>
+		<span>Valheim Server: Turtleheim</span>
 		<span class="rounded-full bg-slate-950 px-2 py-1 font-mono text-xs"
 			>valheim.dean.lol:27029
 		</span>
@@ -169,6 +169,10 @@
 	{:else if isOpen}
 		<!-- Login/Registration form -->
 		<div class="flex flex-col gap-1">
+			<p class="text-xs text-slate-300">
+				Pick any username and enter the <strong>Valheim server password</strong> to add pins &
+				photos. Viewing the map is open to everyone — no sign-in needed.
+			</p>
 			<div class="flex gap-2">
 				<input
 					type="text"

--- a/src/lib/modal/ModalMods.svelte
+++ b/src/lib/modal/ModalMods.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	let { onClose }: { onClose(): void } = $props();
+
+	const SERVER_ADDRESS = 'valheim.dean.lol:27029';
+
+	// Client-required gameplay mods (confirmed loaded on the server). Players must install
+	// matching versions to connect. Links point at Thunderstore search (stays correct even
+	// if a package's author/slug changes).
+	type Mod = { name: string; version: string; note?: string };
+	const REQUIRED_MODS: Mod[] = [
+		{ name: 'PlantEverything', version: '1.20.0' },
+		{ name: 'CraftyCartsRemake', version: '3.1.12' },
+		{ name: 'Guilds', version: '1.1.13' },
+		{ name: 'OdinHorse', version: '1.6.1' },
+		{ name: 'ChestSnap', version: '0.1.1', note: 'client-side mod' }
+	];
+
+	function thunderstore(q: string): string {
+		return `https://thunderstore.io/c/valheim/?q=${encodeURIComponent(q)}`;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onClose();
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+	<dialog
+		class="bg-brand-dark text-brand-fore mx-4 w-full max-w-lg rounded-lg p-0 shadow-lg open:block"
+		open
+		aria-labelledby="mods-modal-title"
+	>
+		<div class="flex items-center justify-between p-3">
+			<h2 id="mods-modal-title" class="text-xl font-semibold">Join Turtleheim</h2>
+			<button
+				class="rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-white"
+				onclick={onClose}
+				aria-label="Close">close</button
+			>
+		</div>
+
+		<div class="max-h-[70vh] overflow-y-auto px-6 pb-6">
+			<!-- Connect -->
+			<div class="mb-4 rounded bg-slate-800 p-3">
+				<div class="text-sm text-slate-300">Connect via “Join IP” in-game:</div>
+				<div class="mt-1 font-mono text-lg">{SERVER_ADDRESS}</div>
+				<div class="mt-1 text-xs text-slate-400">
+					Ask an admin for the server password.
+				</div>
+			</div>
+
+			<!-- Map needs nothing -->
+			<p class="mb-4 rounded border border-emerald-700/50 bg-emerald-900/20 p-3 text-sm">
+				👀 <strong>Just want to view the map?</strong> You need nothing — this page works for
+				everyone, no install required.
+			</p>
+
+			<!-- Required mods -->
+			<h3 class="mb-1 font-semibold">To play on the server, install these mods</h3>
+			<p class="mb-3 text-xs text-slate-400">
+				Match these versions. Easiest with a mod manager (below), which installs BepInEx for you.
+			</p>
+
+			<ul class="mb-4 space-y-2">
+				{#each REQUIRED_MODS as mod (mod.name)}
+					<li class="flex items-center justify-between rounded bg-slate-800 p-2">
+						<div>
+							<span class="font-medium">{mod.name}</span>
+							<span class="ml-2 font-mono text-xs text-slate-400">v{mod.version}</span>
+							{#if mod.note}
+								<span class="ml-2 text-xs text-slate-500">({mod.note})</span>
+							{/if}
+						</div>
+						<a
+							class="rounded bg-sky-600 px-3 py-1 text-xs hover:bg-sky-500"
+							href={thunderstore(mod.name)}
+							target="_blank"
+							rel="noopener noreferrer">find</a
+						>
+					</li>
+				{/each}
+			</ul>
+
+			<!-- How to install -->
+			<h3 class="mb-1 font-semibold">How to install</h3>
+			<ol class="mb-4 list-decimal space-y-1 pl-5 text-sm text-slate-300">
+				<li>
+					Install a mod manager —
+					<a
+						class="text-sky-400 underline"
+						href="https://thunderstore.io/c/valheim/p/ebkr/r2modman/"
+						target="_blank"
+						rel="noopener noreferrer">r2modman</a
+					>
+					or the
+					<a
+						class="text-sky-400 underline"
+						href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager"
+						target="_blank"
+						rel="noopener noreferrer">Thunderstore Mod Manager</a
+					>.
+				</li>
+				<li>Create a Valheim profile — it installs <strong>BepInEx</strong> automatically.</li>
+				<li>Install each mod above (matching versions), then “Start modded”.</li>
+				<li>In Valheim → Join Game → enter <span class="font-mono">{SERVER_ADDRESS}</span>.</li>
+			</ol>
+
+			<p class="text-xs text-slate-500">
+				The live map (WebMap) and pin-sync run on the server only — not in this list, nothing to
+				install for them.
+			</p>
+		</div>
+	</dialog>
+
+	<button
+		class="fixed inset-0 h-full w-full cursor-default bg-transparent"
+		onclick={onClose}
+		aria-label="Close modal"
+		tabindex="-1"
+	></button>
+</div>
+
+<style>
+	dialog {
+		margin: auto;
+		z-index: 51;
+	}
+	dialog::backdrop {
+		display: none;
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds **server-side cartography → web-map pin sync**, plus the Turtleheim frontend updates and a cloud build pipeline.

When a player places personal map pins in-game and hits **"record discoveries"** at a cartography table, their pins now appear on the WebMap HTML map — **no client mods, no external services.** Verified working on the live server (3 personal pins mirrored; boss pins skipped; dedupe confirmed).

## What's included

**Server plugin** — `mods/WebMapCartographySync/` (BepInEx, server-only)
- Polls cartography-table ZDOs, decompresses the shared-map blob, hand-parses pins (no `Minimap` on a headless server), dedupes (deterministic id + vanilla 1-unit proximity), and pushes new pins into WebMap via reflection.
- Accumulates the union across polls (the table only stores the last writer's pins).
- Format verified against decompiled `assembly_valheim`: shared-map **version 3** (`long owner, string name, Vector3 pos, int type, bool checked, string author`).

**CI** — `.github/workflows/build-plugin.yml`
- Builds the plugin in the cloud; fetches Valheim via steamcmd, BepInEx via Thunderstore, WebMap via GitHub. No copyrighted DLLs committed.

**Frontend**
- Nav: server renamed **Turtleheim**, connection address → `valheim.dean.lol:27029`, login help text.
- New **"How to join"** mods panel (`ModalMods`) listing the client mods players need.

**Docs**
- `docs/cartography-pin-sync-spec.md` — design + verified byte format.
- `docs/cartography-pin-deletion.md` — investigation of pin deletion (additive today; per-owner reconciliation sketch for v0.2).

## Notes
- The plugin is already deployed and running on the live server.
- Merging triggers the frontend deploy (`deploy.yml`).
- Deletion is **not** yet supported (see the deletion doc) — additive-only by design for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
